### PR TITLE
ci(pages): fix first deploy — drop linux-unsupported wgpu-native fetch

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -88,7 +88,8 @@ jobs:
           if [ ! -x emsdk/emsdk ]; then
             node make.mjs install-emsdk            # git-clones + installs pinned emsdk/cmake/ninja
           fi
-          node make.mjs fetch-wgpu-native          # pinned WebGPU prebuilt (headers used by the build)
+          # No wgpu-native: it's the native WebGPU backend (extern/CMakeLists.txt
+          # adds it only under NOT BUILD_WASM); the WASM build uses browser WebGPU.
           node make.mjs codegen                    # compile .sbrush kernels -> generated C++ headers
           node make.mjs configure wasm             # picks up CMAKE_BUILD_TYPE=Release from local-build-options.mjs
           node make.mjs build wasm                 # emits + copies sculptcore-browser.{wasm,js} into typescript/build

--- a/Readme.MD
+++ b/Readme.MD
@@ -1,8 +1,6 @@
 ## WebGL-App-Framework
 ![alt text](image.png)
-[Try it out here](https://joeedh.github.io/webgl-app-framework/index.html)
-
-[Docs](https://joeedh.github.io/webgl-app-framework/docs/index.html)
+[Try it out here](https://joeedh.github.io/webgl-app-framework/)
 
 ## Checkout
 


### PR DESCRIPTION
The first Pages deploy (run on the PR #26 merge) failed in **Build sculptcore WASM** with:

```
Error: wgpu-native fetch: unsupported platform linux/x64
Command failed: node extern/wgpu_native/fetch.mjs
```

`wgpu-native` is the **native** WebGPU backend — `extern/CMakeLists.txt` adds it only under `if (NOT BUILD_WASM)`, and its prebuilt ships no `linux/x64` asset. The WASM build uses the browser's WebGPU and never links it, so the `node make.mjs fetch-wgpu-native` step was both unnecessary and the cause of the failure. This removes it.

Everything before that step worked on the runner (checkout+submodules, pnpm/Node, deps, emsdk install + cmake/ninja, Release `local-build-options.mjs`). With this fix the build proceeds to codegen → configure → `build wasm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)