### PR TITLE
ci(pages): ship externalized runtime libs (fix app 404s)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -112,6 +112,14 @@ jobs:
           cp index.html _site/
           cp -r build _site/build
           cp -r assets _site/assets
+          # esbuild keeps three libs *external* (see external[] in esbuilder.js),
+          # so at runtime build/entry_point.js imports them from ../scripts/... —
+          # i.e. site-root /scripts/...  Ship exactly those files; the rest of the
+          # 277 MB source tree is bundled into build/ and not served.
+          mkdir -p _site/scripts/extern/jszip _site/scripts/util
+          cp scripts/extern/jszip/jszip.js _site/scripts/extern/jszip/jszip.js
+          cp scripts/extern/Math.js        _site/scripts/extern/Math.js
+          cp scripts/util/numeric.js       _site/scripts/util/numeric.js
           # Pages serves from a per-repo subpath; all app references are relative,
           # so no <base> rewrite is needed. SPA-style 404 fallback:
           cp index.html _site/404.html


### PR DESCRIPTION
Deployed app 404'd on jszip.js / Math.js / numeric.js → cascaded into 'failed to fetch dynamically imported module entry_point.js'. These three are esbuild `external`s loaded at runtime from /scripts/..., but the site only shipped build/ + assets/. Copy exactly those three files into _site. WASM is cached by sculptcore SHA so this run only re-bundles.