### PR TITLE
ci(pages): external sourcemaps (shrink served entry_point.js)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -103,6 +103,12 @@ jobs:
 
       # ---- App bundle + site assembly --------------------------------------
       - name: Bundle app (esbuild)
+        env:
+          # External (not inline) sourcemaps: keeps the served entry_point.js
+          # small (~20 MB inline map moves into a separate .map, fetched only
+          # when devtools are open). esbuild 'external' emits the .map without a
+          # sourceMappingURL comment, so normal page loads never download it.
+          ESBUILD_SOURCEMAP: external
         run: pnpm build # node tools/esbuilder.js -> ./build
 
       - name: Assemble Pages site

--- a/tools/esbuilder.js
+++ b/tools/esbuilder.js
@@ -29,7 +29,11 @@ let options = {
   outdir     : './build',
   bundle     : true,
   target     : 'es2022',
-  sourcemap  : 'inline',
+  // Overridable for the Pages build (ESBUILD_SOURCEMAP=external) so the served
+  // entry_point.js isn't bloated by its ~20 MB inline map. Defaults to inline
+  // for local dev (single file, no extra fetch). Accepts any esbuild sourcemap
+  // mode: inline | external | linked | both.
+  sourcemap  : process.env.ESBUILD_SOURCEMAP || 'inline',
   minify     : false,
   treeShaking: false,
   logLevel   : 'info',


### PR DESCRIPTION
esbuild used inline sourcemaps, bloating the deployed entry_point.js to ~22 MB. Make the mode overridable via `ESBUILD_SOURCEMAP` (default `inline` for local dev) and set `external` in the Pages bundle step. Verified locally: entry_point.js 22.4 MB → 6.3 MB, map moves to a separate .map with no sourceMappingURL comment (not fetched on normal loads).