### PR TITLE
ci(pages): inject coi-serviceworker for SharedArrayBuffer support

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -126,9 +126,18 @@ jobs:
           cp scripts/extern/jszip/jszip.js _site/scripts/extern/jszip/jszip.js
           cp scripts/extern/Math.js        _site/scripts/extern/Math.js
           cp scripts/util/numeric.js       _site/scripts/util/numeric.js
+          # sculptcore's WASM pthread pool needs SharedArrayBuffer, which requires
+          # cross-origin isolation (COOP+COEP). GitHub Pages can't set those
+          # response headers, so coi-serviceworker installs a SW that injects them
+          # client-side and reloads once to take effect. Served from site root so
+          # its scope covers the whole app; injected only here (Pages), leaving the
+          # committed index.html — and the Electron/dev paths — untouched.
+          cp coi-serviceworker.js _site/coi-serviceworker.js
+          sed -i 's#<head>#<head>\n  <script src="coi-serviceworker.js"></script>#' _site/index.html
           # Pages serves from a per-repo subpath; all app references are relative,
-          # so no <base> rewrite is needed. SPA-style 404 fallback:
-          cp index.html _site/404.html
+          # so no <base> rewrite is needed. SPA-style 404 fallback (inherits the
+          # coi-serviceworker injection from the patched index.html):
+          cp _site/index.html _site/404.html
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/coi-serviceworker.js
+++ b/coi-serviceworker.js
@@ -1,0 +1,146 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof and contributors, licensed under MIT */
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+    self.addEventListener("message", (ev) => {
+        if (!ev.data) {
+            return;
+        } else if (ev.data.type === "deregister") {
+            self.registration
+                .unregister()
+                .then(() => {
+                    return self.clients.matchAll();
+                })
+                .then(clients => {
+                    clients.forEach((client) => client.navigate(client.url));
+                });
+        } else if (ev.data.type === "coepCredentialless") {
+            coepCredentialless = ev.data.value;
+        }
+    });
+
+    self.addEventListener("fetch", function (event) {
+        const r = event.request;
+        if (r.cache === "only-if-cached" && r.mode !== "same-origin") {
+            return;
+        }
+
+        const request = (coepCredentialless && r.mode === "no-cors")
+            ? new Request(r, {
+                credentials: "omit",
+            })
+            : r;
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.status === 0) {
+                        return response;
+                    }
+
+                    const newHeaders = new Headers(response.headers);
+                    newHeaders.set("Cross-Origin-Embedder-Policy",
+                        coepCredentialless ? "credentialless" : "require-corp"
+                    );
+                    if (!coepCredentialless) {
+                        newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+                    }
+                    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+
+                    return new Response(response.body, {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers: newHeaders,
+                    });
+                })
+                .catch((e) => console.error(e))
+        );
+    });
+
+} else {
+    (() => {
+        const reloadedBySelf = window.sessionStorage.getItem("coiReloadedBySelf");
+        window.sessionStorage.removeItem("coiReloadedBySelf");
+        const coepDegrading = (reloadedBySelf == "coepdegrade");
+
+        // You can customize the behavior of this script through a global `coi` variable.
+        const coi = {
+            shouldRegister: () => !reloadedBySelf,
+            shouldDeregister: () => false,
+            coepCredentialless: () => true,
+            coepDegrade: () => true,
+            doReload: () => window.location.reload(),
+            quiet: false,
+            ...window.coi
+        };
+
+        const n = navigator;
+        const controlling = n.serviceWorker && n.serviceWorker.controller;
+
+        // Record the failure if the page is served by serviceWorker.
+        if (controlling && !window.crossOriginIsolated) {
+            window.sessionStorage.setItem("coiCoepHasFailed", "true");
+        }
+        const coepHasFailed = window.sessionStorage.getItem("coiCoepHasFailed");
+
+        if (controlling) {
+            // Reload only on the first failure.
+            const reloadToDegrade = coi.coepDegrade() && !(
+                coepDegrading || window.crossOriginIsolated
+            );
+            n.serviceWorker.controller.postMessage({
+                type: "coepCredentialless",
+                value: (reloadToDegrade || coepHasFailed && coi.coepDegrade())
+                    ? false
+                    : coi.coepCredentialless(),
+            });
+            if (reloadToDegrade) {
+                !coi.quiet && console.log("Reloading page to degrade COEP.");
+                window.sessionStorage.setItem("coiReloadedBySelf", "coepdegrade");
+                coi.doReload("coepdegrade");
+            }
+
+            if (coi.shouldDeregister()) {
+                n.serviceWorker.controller.postMessage({ type: "deregister" });
+            }
+        }
+
+        // If we're already coi: do nothing. Perhaps it's due to this script doing its job, or COOP/COEP are
+        // already set from the origin server. Also if the browser has no notion of crossOriginIsolated, just give up here.
+        if (window.crossOriginIsolated !== false || !coi.shouldRegister()) return;
+
+        if (!window.isSecureContext) {
+            !coi.quiet && console.log("COOP/COEP Service Worker not registered, a secure context is required.");
+            return;
+        }
+
+        // In some environments (e.g. Firefox private mode) this won't be available
+        if (!n.serviceWorker) {
+            !coi.quiet && console.error("COOP/COEP Service Worker not registered, perhaps due to private mode.");
+            return;
+        }
+
+        n.serviceWorker.register(window.document.currentScript.src).then(
+            (registration) => {
+                !coi.quiet && console.log("COOP/COEP Service Worker registered", registration.scope);
+
+                registration.addEventListener("updatefound", () => {
+                    !coi.quiet && console.log("Reloading page to make use of updated COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "updatefound");
+                    coi.doReload();
+                });
+
+                // If the registration is active, but it's not controlling the page
+                if (registration.active && !n.serviceWorker.controller) {
+                    !coi.quiet && console.log("Reloading page to make use of COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "notcontrolling");
+                    coi.doReload();
+                }
+            },
+            (err) => {
+                !coi.quiet && console.error("COOP/COEP Service Worker failed to register:", err);
+            }
+        );
+    })();
+}


### PR DESCRIPTION
## Problem

The deployed Pages site throws a SharedArrayBuffer error: sculptcore's WASM pthread pool needs `SharedArrayBuffer`, which the browser only exposes in a **cross-origin-isolated** context (requires COOP `same-origin` + COEP `require-corp`/`credentialless` response headers). GitHub Pages can't set those headers.

## Fix

Vendor [`coi-serviceworker`](https://github.com/gzuidhof/coi-serviceworker) v0.1.7 (MIT) and wire it into the Pages build only:

- Copy `coi-serviceworker.js` to the `_site` root (so its SW scope covers the whole app).
- `sed`-inject `<script src="coi-serviceworker.js"></script>` right after `<head>` in `_site/index.html`, then derive `_site/404.html` from the patched file.

The service worker registers on first load, re-serves every response with the isolation headers, and reloads once so `crossOriginIsolated` becomes true and `SharedArrayBuffer` is available.

The injection happens **only in the workflow**, against the deploy artifact — the committed `index.html` (and the Electron/dev boot paths) are untouched. coi-serviceworker is a no-op when a context is already cross-origin-isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)